### PR TITLE
Add version field to PulumiPolicy.yaml Python templates

### DIFF
--- a/aws-python/PulumiPolicy.yaml
+++ b/aws-python/PulumiPolicy.yaml
@@ -1,2 +1,3 @@
 description: A minimal Policy Pack for AWS using Python.
 runtime: python
+version: 0.0.1

--- a/azure-python/PulumiPolicy.yaml
+++ b/azure-python/PulumiPolicy.yaml
@@ -1,2 +1,3 @@
 description: A minimal Policy Pack for Azure using Python.
 runtime: python
+version: 0.0.1

--- a/gcp-python/PulumiPolicy.yaml
+++ b/gcp-python/PulumiPolicy.yaml
@@ -1,2 +1,3 @@
 description: A minimal Policy Pack for GCP using Python.
 runtime: python
+version: 0.0.1

--- a/kubernetes-python/PulumiPolicy.yaml
+++ b/kubernetes-python/PulumiPolicy.yaml
@@ -1,2 +1,3 @@
 description: A minimal Policy Pack for Kubernetes using Python.
 runtime: python
+version: 0.0.1


### PR DESCRIPTION
This is how the version is specified for Python policy packs published to the service.

Follow-up from https://github.com/pulumi/pulumi/pull/4644