### PR TITLE
Make the aws-python template match aws-typescript/aws-javascript templates.

### DIFF
--- a/aws-python/__main__.py
+++ b/aws-python/__main__.py
@@ -17,12 +17,12 @@ def s3_no_public_read_validator(args: ResourceValidationArgs, report_violation: 
 s3_no_public_read = ResourceValidationPolicy(
     name="s3-no-public-read",
     description="Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+    enforcement_level=EnforcementLevel.MANDATORY,
     validate=s3_no_public_read_validator,
 )
 
 PolicyPack(
     name="aws-python",
-    enforcement_level=EnforcementLevel.MANDATORY,
     policies=[
         s3_no_public_read,
     ],


### PR DESCRIPTION
There's a small discrepancy between the `aws-python` template and the `aws-typescript` and `aws-javascript` examples.

In the Python example, the enforcement level is set on the policy pack, while in the TS/JS example, the enforcement level is set on the policy. These templates should produce the same example to avoid confusion.