### PR TITLE
Add OPA (Rego) policy pack templates

### DIFF
--- a/aws-opa/PulumiPolicy.yaml
+++ b/aws-opa/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+description: A minimal Policy Pack for AWS using OPA.
+runtime: opa
+version: 0.0.1

--- a/aws-opa/policy.rego
+++ b/aws-opa/policy.rego
@@ -1,0 +1,12 @@
+package aws
+
+# METADATA
+# title: No Public S3 Buckets
+# description: S3 buckets must not use public-read ACLs.
+# custom:
+#   message: Set the ACL to 'private' or remove it entirely.
+deny_public_buckets[msg] {
+    input.type == "aws:s3/bucket:Bucket"
+    input.acl == "public-read"
+    msg := sprintf("S3 bucket '%s' must not have public-read ACL", [input.__name])
+}

--- a/azure-opa/PulumiPolicy.yaml
+++ b/azure-opa/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+description: A minimal Policy Pack for Azure using OPA.
+runtime: opa
+version: 0.0.1

--- a/azure-opa/policy.rego
+++ b/azure-opa/policy.rego
@@ -1,0 +1,12 @@
+package azure
+
+# METADATA
+# title: No Public Storage Containers
+# description: Storage containers must not allow public access.
+# custom:
+#   message: Set containerAccessType to 'private' or remove it entirely.
+deny_public_containers[msg] {
+    input.type == "azure-native:storage:BlobContainer"
+    input.publicAccess != "None"
+    msg := sprintf("Storage container '%s' must not allow public access", [input.__name])
+}

--- a/gcp-opa/PulumiPolicy.yaml
+++ b/gcp-opa/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+description: A minimal Policy Pack for Google Cloud using OPA.
+runtime: opa
+version: 0.0.1

--- a/gcp-opa/policy.rego
+++ b/gcp-opa/policy.rego
@@ -1,0 +1,12 @@
+package gcp
+
+# METADATA
+# title: No Public Storage Buckets
+# description: Storage buckets must not allow public access via allUsers or allAuthenticatedUsers.
+# custom:
+#   message: Remove allUsers or allAuthenticatedUsers from the bucket's IAM bindings.
+deny_public_buckets[msg] {
+    input.type == "gcp:storage/bucketIAMMember:BucketIAMMember"
+    input.member == "allUsers"
+    msg := sprintf("Storage bucket IAM member '%s' must not grant access to allUsers", [input.__name])
+}

--- a/kubernetes-opa/PulumiPolicy.yaml
+++ b/kubernetes-opa/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+description: A minimal Policy Pack for Kubernetes using OPA.
+runtime: opa
+version: 0.0.1

--- a/kubernetes-opa/policy.rego
+++ b/kubernetes-opa/policy.rego
@@ -1,0 +1,13 @@
+package kubernetes
+
+# METADATA
+# title: No Privileged Containers
+# description: Containers must not run in privileged mode.
+# custom:
+#   message: Set securityContext.privileged to false.
+deny_privileged[msg] {
+    input.type == "kubernetes:apps/v1:Deployment"
+    container := input.spec.template.spec.containers[_]
+    container.securityContext.privileged == true
+    msg := sprintf("Container '%s' in Deployment '%s' must not run in privileged mode", [container.name, input.__name])
+}


### PR DESCRIPTION
## Summary
- Add `aws-opa`, `azure-opa`, `gcp-opa`, and `kubernetes-opa` templates for OPA-based policy packs
- Each template contains a `PulumiPolicy.yaml` (runtime: opa) and a `policy.rego` with a provider-relevant starter deny rule
- Uses OPA metadata annotations (`# METADATA` blocks with `title`, `description`, `custom.message`)

Closes #35

## Test plan
- [x] Verify `pulumi policy new aws-opa` scaffolds the template correctly
- [x] Verify `pulumi policy new azure-opa` scaffolds the template correctly
- [x] Verify `pulumi policy new gcp-opa` scaffolds the template correctly
- [x] Verify `pulumi policy new kubernetes-opa` scaffolds the template correctly
- [x] Confirm each `policy.rego` is valid Rego syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)