### PR TITLE
Update AWS policy templates for provider v7 and add CI verification

### DIFF
--- a/.github/workflows/verify-policy.yml
+++ b/.github/workflows/verify-policy.yml
@@ -1,0 +1,21 @@
+name: Verify policy templates
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: mise run verify-policy

--- a/aws-javascript/index.js
+++ b/aws-javascript/index.js
@@ -5,12 +5,12 @@ const policy = require("@pulumi/policy");
 new policy.PolicyPack("aws-javascript", {
     policies: [{
         name: "s3-no-public-read",
-        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 bucket ACLs.",
         enforcementLevel: "mandatory",
-        validateResource: policy.validateResourceOfType(aws.s3.Bucket, (bucket, args, reportViolation) => {
-            if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
+        validateResource: policy.validateResourceOfType(aws.s3.BucketAcl, (bucketAcl, args, reportViolation) => {
+            if (bucketAcl.acl === "public-read" || bucketAcl.acl === "public-read-write") {
                 reportViolation(
-                    "You cannot set public-read or public-read-write on an S3 bucket. " +
+                    "You cannot set public-read or public-read-write on an S3 bucket ACL. " +
                     "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
             }
         }),

--- a/aws-javascript/package.json
+++ b/aws-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "aws-javascript",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws": "^7.0.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/policy": "^1.20.0"
     },

--- a/aws-opa/policy.rego
+++ b/aws-opa/policy.rego
@@ -1,12 +1,18 @@
 package aws
 
 # METADATA
-# title: No Public S3 Buckets
-# description: S3 buckets must not use public-read ACLs.
+# title: No Public S3 Bucket ACLs
+# description: S3 bucket ACLs must not use public-read or public-read-write.
 # custom:
 #   message: Set the ACL to 'private' or remove it entirely.
 deny_public_buckets[msg] {
-    input.type == "aws:s3/bucket:Bucket"
+    input.type == "aws:s3/bucketAcl:BucketAcl"
     input.acl == "public-read"
-    msg := sprintf("S3 bucket '%s' must not have public-read ACL", [input.__name])
+    msg := sprintf("S3 bucket ACL '%s' must not have public-read ACL", [input.__name])
+}
+
+deny_public_buckets[msg] {
+    input.type == "aws:s3/bucketAcl:BucketAcl"
+    input.acl == "public-read-write"
+    msg := sprintf("S3 bucket ACL '%s' must not have public-read-write ACL", [input.__name])
 }

--- a/aws-python/__main__.py
+++ b/aws-python/__main__.py
@@ -7,16 +7,16 @@ from pulumi_policy import (
 )
 
 def s3_no_public_read_validator(args: ResourceValidationArgs, report_violation: ReportViolation):
-    if args.resource_type == "aws:s3/bucket:Bucket" and "acl" in args.props:
+    if args.resource_type == "aws:s3/bucketAcl:BucketAcl" and "acl" in args.props:
         acl = args.props["acl"]
         if acl == "public-read" or acl == "public-read-write":
             report_violation(
-                "You cannot set public-read or public-read-write on an S3 bucket. " +
+                "You cannot set public-read or public-read-write on an S3 bucket ACL. " +
                 "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html")
 
 s3_no_public_read = ResourceValidationPolicy(
     name="s3-no-public-read",
-    description="Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+    description="Prohibits setting the publicRead or publicReadWrite permission on AWS S3 bucket ACLs.",
     enforcement_level=EnforcementLevel.MANDATORY,
     validate=s3_no_public_read_validator,
 )

--- a/aws-typescript/index.ts
+++ b/aws-typescript/index.ts
@@ -4,12 +4,12 @@ import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
 new PolicyPack("aws-typescript", {
     policies: [{
         name: "s3-no-public-read",
-        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 bucket ACLs.",
         enforcementLevel: "mandatory",
-        validateResource: validateResourceOfType(aws.s3.Bucket, (bucket, args, reportViolation) => {
-            if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
+        validateResource: validateResourceOfType(aws.s3.BucketAcl, (bucketAcl, args, reportViolation) => {
+            if (bucketAcl.acl === "public-read" || bucketAcl.acl === "public-read-write") {
                 reportViolation(
-                    "You cannot set public-read or public-read-write on an S3 bucket. " +
+                    "You cannot set public-read or public-read-write on an S3 bucket ACL. " +
                     "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
             }
         }),

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "aws-typescript",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws": "^7.0.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/policy": "^1.20.0"
     },

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+[tools]
+nodejs = "26.3.0"
+python = "3.14"
+opa = "0.68.0"
+pipx = "1.14.0"
+
+[tasks.verify-policy]
+description = "Run policy template verification"
+run = "./scripts/verify-policy.sh"

--- a/scripts/aws-opa-policy_test.rego
+++ b/scripts/aws-opa-policy_test.rego
@@ -1,0 +1,33 @@
+package aws
+
+test_deny_public_read_acl {
+    count(deny_public_buckets) > 0 with input as {
+        "type": "aws:s3/bucketAcl:BucketAcl",
+        "__name": "my-bucket-acl",
+        "acl": "public-read",
+    }
+}
+
+test_deny_public_read_write_acl {
+    count(deny_public_buckets) > 0 with input as {
+        "type": "aws:s3/bucketAcl:BucketAcl",
+        "__name": "my-bucket-acl",
+        "acl": "public-read-write",
+    }
+}
+
+test_allow_private_acl {
+    count(deny_public_buckets) == 0 with input as {
+        "type": "aws:s3/bucketAcl:BucketAcl",
+        "__name": "my-bucket-acl",
+        "acl": "private",
+    }
+}
+
+test_ignore_deprecated_bucket_acl {
+    count(deny_public_buckets) == 0 with input as {
+        "type": "aws:s3/bucket:Bucket",
+        "__name": "my-bucket",
+        "acl": "public-read",
+    }
+}

--- a/scripts/verify-policy.sh
+++ b/scripts/verify-policy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TS_PKG="${ROOT}/aws-typescript"
+JS_PKG="${ROOT}/aws-javascript"
+PY_PKG="${ROOT}/aws-python"
+OPA_POLICY="${ROOT}/aws-opa/policy.rego"
+OPA_TESTS="${ROOT}/scripts/aws-opa-policy_test.rego"
+
+failures=0
+
+log() {
+    printf '==> %s\n' "$*"
+}
+
+run_check() {
+    local name="$1"
+    shift
+
+    log "$name"
+    if "$@"; then
+        printf '    ok\n'
+    else
+        printf '    failed\n' >&2
+        failures=$((failures + 1))
+    fi
+}
+
+require_command() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        printf 'missing required command: %s\n' "$name" >&2
+        exit 1
+    fi
+}
+
+verify_opa() {
+    require_command opa
+    opa test "$OPA_POLICY" "$OPA_TESTS" -v
+}
+
+verify_typescript() {
+    require_command npm
+    require_command npx
+
+    (
+        cd "$TS_PKG"
+        npm install --silent
+        npx --yes -p typescript@5 tsc --noEmit --skipLibCheck -p tsconfig.json
+    )
+}
+
+verify_javascript() {
+    require_command npm
+    require_command npx
+
+    (
+        cd "$JS_PKG"
+        npm install --silent
+        npx --yes -p typescript@5 tsc --allowJs --checkJs --noEmit --skipLibCheck \
+            --module commonjs --moduleResolution node --target es6 --strict index.js
+    )
+}
+
+# aws-python/__main__.py is the Python policy pack entry point: pulumi policy new
+# aws-python scaffolds it, and Pulumi loads it at preview/up to run the pack's rules.
+verify_python() {
+    require_command python
+    require_command pipx
+
+    local requirement module
+
+    (
+        cd "$PY_PKG"
+        python -m py_compile __main__.py
+
+        while IFS= read -r requirement || [ -n "$requirement" ]; do
+            [ -z "$requirement" ] && continue
+            case "$requirement" in
+                pulumi-policy*) module=pulumi_policy ;;
+                pulumi-aws*) module=pulumi_aws ;;
+                *)
+                    printf 'unsupported requirement: %s\n' "$requirement" >&2
+                    return 1
+                    ;;
+            esac
+            pipx run --spec "$requirement" python -c "import ${module}"
+        done < requirements.txt
+    )
+}
+
+main() {
+    run_check "OPA policy tests" verify_opa
+    run_check "TypeScript typecheck (aws-typescript)" verify_typescript
+    run_check "JavaScript typecheck (aws-javascript)" verify_javascript
+    run_check "Python compile/import check (aws-python)" verify_python
+
+    if [ "$failures" -ne 0 ]; then
+        printf '%d check(s) failed\n' "$failures" >&2
+        exit 1
+    fi
+
+    log "all policy checks passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Update the AWS starter policy templates (TypeScript, JavaScript, Python, and OPA) to validate `aws.s3.BucketAcl` instead of the deprecated `Bucket.acl` property in AWS provider v7
- Re-apply the Renovate `@pulumi/aws` v7 dependency bump that was reverted in #43
- Add a `scripts/verify-policy.sh` check and a GitHub Actions workflow (via mise) to catch template breakage on PRs and pushes to `master`

## Test plan

- [x] `mise run verify-policy` passes locally
- [ ] GitHub Actions `Verify policy templates` workflow passes on this PR
- [ ] `pulumi policy new aws-typescript` / `aws-javascript` / `aws-python` / `aws-opa` scaffolds still work as expected